### PR TITLE
feat: add trailing whitespace check and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -1,0 +1,22 @@
+name: Check trailing whitespace
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  whitespace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for trailing whitespace
+        run: |
+          if grep -rn ' $' --include='*.md' .; then
+            echo ""
+            echo "ERROR: Trailing whitespace found in the files above."
+            echo "Please remove trailing whitespace before merging."
+            exit 1
+          fi
+          echo "No trailing whitespace found."


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`check-whitespace.yml`) that runs on PRs and pushes to `main`, failing if any `.md` files contain trailing whitespace
- Adds an `.editorconfig` so contributors' editors auto-strip trailing whitespace on save

👾 Generated with [Letta Code](https://letta.com)